### PR TITLE
Fixes instance variables bitWidth and addressWidth in RamResizable.cs

### DIFF
--- a/cheeseutil/src/server/RamResizable.cs
+++ b/cheeseutil/src/server/RamResizable.cs
@@ -14,8 +14,8 @@ namespace CheeseUtilMod.Components
         private static int PEG_CS = 0;
         private static int PEG_W = 1;
         private static int PEG_L = 2;
-        private static int bitWidth;
-        private static int addressWidth;
+        private int bitWidth;
+        private int addressWidth;
         private bool loadfromsave;
         private byte[] memory;
 


### PR DESCRIPTION
bitWidth and addressWidth variables in RamResizable.cs were static causing contents to be cleared at random times, also causing file loading issues.