### PR TITLE
Make CheeseLoader an optional mod

### DIFF
--- a/cheeseloader/manifest.jecs
+++ b/cheeseloader/manifest.jecs
@@ -1,5 +1,6 @@
-﻿ID: cheeseloader
+ID: cheeseloader
 Name: CheeseLoader
 Author: Cheese
-Version: 1.1
+Version: 1.2
 Priority: 91
+Optional: true


### PR DESCRIPTION
CheeserLoader is effectively "server only" LW does not have that yet. But it now has "optional mods" which is the closest to server-only. Also ServerOnlyMods is now obsolete - this mod should switch to the new solution.